### PR TITLE
Chooses the newest certificate (so that this is consistent with the Configure.ps automation script)

### DIFF
--- a/TodoListDaemonWithCert/Program.cs
+++ b/TodoListDaemonWithCert/Program.cs
@@ -81,7 +81,7 @@ namespace TodoListDaemonWithCert
                     return;
                 }
                 // Return the first certificate in the collection, has the right name and is current.
-                cert = signingCert[0];
+                cert = signingCert.OfType< X509Certificate2>().OrderByDescending(c => c.NotBefore).First();
             }
             finally
             {


### PR DESCRIPTION
Currently if there are several certificate of the same name in the certificate store, we pick-up any randomly. This fix proposes to pickup the certificate the most recently added. This is especially important when running the Configure.ps script to be sure that the DaemonWithCert application proposes the right certificate.