### PR TITLE
Updating PowerShell scripts to enable Continuous Integration / Continuous Delivery (automated testing of the sample)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,3 +106,4 @@ Generated_Code #added for RIA/Silverlight projects
 _UpgradeReport_Files/
 Backup*/
 UpgradeLog*.XML
+/.vs

--- a/Cleanup.ps1
+++ b/Cleanup.ps1
@@ -11,7 +11,7 @@ This function removes the Azure AD applications for the sample. These applicatio
 #>
     [CmdletBinding()]
     param(
-        [Parameter(Mandatory=$True, HelpMessage='Tenant ID (This is a GUID which represents the "Directory ID" of the AzureAD tenant into which you want to create the apps')]
+        [Parameter(HelpMessage='Tenant ID (This is a GUID which represents the "Directory ID" of the AzureAD tenant into which you want to create the apps')]
         [PSCredential] $Credential,
         [string] $tenantId
     )
@@ -29,7 +29,7 @@ This function removes the Azure AD applications for the sample. These applicatio
     }
     else
     {
-        if (!$TenantId)
+        if (!$tenantId)
         {
             $creds = Connect-AzureAD -Credential $Credential
         }
@@ -49,14 +49,14 @@ This function removes the Azure AD applications for the sample. These applicatio
     . .\Parameters.ps1
 
     # Removes the applications
-    Write-Host "Removing Application '$serviceAppIdURI'"
+    Write-Host "Removing Application '$serviceAppIdURI' if needed"
     $app=Get-AzureADApplication -Filter "identifierUris/any(uri:uri eq '$serviceAppIdURI')"  
     if ($app)
     {
         Remove-AzureADApplication -ObjectId $app.ObjectId
     }
 
-      Write-Host "Removing Application '$daemonAppIdURI'"
+      Write-Host "Removing Application '$daemonAppIdURI' if needed"
     $app=Get-AzureADApplication -Filter "identifierUris/any(uri:uri eq '$daemonAppIdURI')"      
     if ($app)
     {

--- a/Cleanup.ps1
+++ b/Cleanup.ps1
@@ -1,0 +1,70 @@
+param([PSCredential]$Credential, [string]$TenantId)
+Import-Module AzureAD
+$ErrorActionPreference = 'Stop'
+
+
+Function Cleanup
+{
+<#
+.Description
+This function removes the Azure AD applications for the sample. These applications were created by the Configure.ps1 script
+#>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory=$True, HelpMessage='Tenant ID (This is a GUID which represents the "Directory ID" of the AzureAD tenant into which you want to create the apps')]
+        [PSCredential] $Credential,
+        [string] $tenantId
+    )
+
+   process
+   {
+    # $tenantId is the Active Directory Tenant. This is a GUID which represents the "Directory ID" of the AzureAD tenant 
+    # into which you want to create the apps. Look it up in the Azure portal in the "Properties" of the Azure AD. 
+
+    # Login to Azure PowerShell (interactive if credentials are not already provided: 
+    # you'll need to sign-in with creds enabling your to create apps in the tenant)
+    if (!$Credential)
+    {
+        $creds = Connect-AzureAD -TenantId $tenantId
+    }
+    else
+    {
+        if (!$TenantId)
+        {
+            $creds = Connect-AzureAD -Credential $Credential
+        }
+        else
+        {
+            $creds = Connect-AzureAD -TenantId $tenantId -Credential $Credential
+        }
+    }
+
+    if (!$tenantId)
+    {
+        $tenantId = $creds.Tenant.Id
+    }
+    $tenant = Get-AzureADTenantDetail
+    $tenantName =  $tenant.VerifiedDomains[0].Name
+
+    . .\Parameters.ps1
+
+    # Removes the applications
+    Write-Host "Removing Application '$serviceAppIdURI'"
+    $app=Get-AzureADApplication -Filter "identifierUris/any(uri:uri eq '$serviceAppIdURI')"  
+    if ($app)
+    {
+        Remove-AzureADApplication -ObjectId $app.ObjectId
+    }
+
+      Write-Host "Removing Application '$daemonAppIdURI'"
+    $app=Get-AzureADApplication -Filter "identifierUris/any(uri:uri eq '$daemonAppIdURI')"      
+    if ($app)
+    {
+        Remove-AzureADApplication -ObjectId $app.ObjectId
+    }
+    
+       Write-Host "Done."
+   }
+}
+
+Cleanup -Credential $Credential -tenantId $TenantId

--- a/Configure.ps1
+++ b/Configure.ps1
@@ -19,7 +19,7 @@
 #
 # To cleanup
 # 6) Optionnaly if you want to cleanup the applications in the Azure AD, run:
-#      cleanup($apps)
+#      Cleanup $apps
 #    The applications are un-registered
 
 $ErrorActionPreference = 'Stop'
@@ -144,7 +144,7 @@ of the visual studio solution (App.Config and Web.Config) so that they are consi
 
 
 # Remove the AAD applications and service principals registered for the sample.
-Function CleanUp($applicationsInformation)
+Function Cleanup($applicationsInformation)
 {
     remove-azurermadserviceprincipal -objectid $applicationsInformation.serviceAppServicePrincipal.id
     remove-azurermadapplication -objectid $applicationsInformation.serviceApp.objectid

--- a/Configure.ps1
+++ b/Configure.ps1
@@ -4,8 +4,8 @@
 # Before running this script you need to install the Azure RM cmdlets as an administrator. 
 # For this:
 # 1) Run Powershell as an administrator
-# 2) in the PowerShell window, type: Install-Module AzureRM.Resources
-#
+# 2) in the PowerShell window, type: Install-Module AzureAD
+
 # To prepare this script
 # 3) With the Azure portal (https://portal.azure.com), choose your active directory tenant, then go to the Properties of the tenant and copy
 #    the DirectoryID. This is what we'll use in this script for the tenant ID
@@ -63,7 +63,6 @@ Function UpdateServiceConfigFile([string] $configFilePath, [string] $tenantId, [
     ReplaceSetting -configFilePath $configFilePath -key "ida:Audience" -newValue $audience
 }
 
-
 Function ConfigureApplications
 {
 <#
@@ -82,62 +81,63 @@ of the visual studio solution (App.Config and Web.Config) so that they are consi
     # Active Directory Tenant. This is a GUID which represents the "Directory ID" of the AzureAD tenant into which you want to create the apps.
     # Look it up in the Azure portal in the "Properties" of the Azure AD. 
     # IN THE FUTURE: We'd like to be able to get the tenant name from the tenant ID (or pass the tenant name as an argument)
-    $tenantName = $tenantId
+
+    # Login to Azure PowerShell (interactive: you'll need to sign-in with creds enabling your to create apps in the tenant)
+    $creds = Connect-AzureAD -TenantId $tenantId
+     if (!$tenantId)
+     {
+         $tenantId = $creds.Tenant.Id
+     }
+    $tenant = Get-AzureADTenantDetail
+    $tenantName =  $tenant.VerifiedDomains[0].Name
 
     # Variables for the registration of the AAD application for the Web API Service
     $serviceAadAppName = "TodoListService"
     $serviceHomePage = "https://localhost:44321"
-    $serviceAppIdIRI = "https://"+$tenantName+"/"+$serviceAadAppName
+    $serviceAppIdURI = "https://"+$tenantName+"/"+$serviceAadAppName
 
     # Variables for the registration of the AAD application for the Daemon app
     $daemonAadAppName = "TodoListDaemonWithCert"
     $daemonHomePage = "http://TodoListDaemonWithCert"
-    $daemonAppIdIRI = "http://TodoListDaemonWithCert"
+    $daemonAppIdURI = "http://TodoListDaemonWithCert"
     $certificateName = "CN=TodoListDaemonWithCert"
 
-    # Import required modules
-    Import-Module AzureRM.Resources
-
-    # Login to Azure PowerShell (interactive: you'll need to sign-in with creds enabling your to create apps in the tenant)
-    $creds = Login-AzureRmAccount -TenantId $tenantId
 
     # Create the Azure Active Directory Application and it's service principal
     # Note that if, at this point, you get an error: "New-AzureRmADApplication : Your Azure credentials have not been set up or have expired, please run Login-AzureRMAccount to set up your Azure credentials"
     # then you will need to run Clear-AzureProfile (you might have an expired token)
     Write-Host "Creating the service appplication ($serviceAadAppName)"
-    $serviceApplication = New-AzureRmADApplication -DisplayName $serviceAadAppName -HomePage $serviceHomePage -IdentifierUris $serviceAppIdIRI
-    $serviceservicePrincipal = New-AzureRmADServicePrincipal -ApplicationId $serviceApplication.ApplicationId
+    $serviceApplication =New-AzureADApplication -DisplayName $serviceAadAppName -HomePage $serviceHomePage -IdentifierUris $serviceAppIdURI
+    $serviceservicePrincipal = New-AzureADServicePrincipal -AppId $serviceApplication.AppId
 
     # Create the daemon application
     # ------------------------------
+    # And create the daemon application
+    $daemonApplication = New-AzureADApplication  -DisplayName $daemonAadAppName -HomePage $daemonHomePage -IdentifierUris $daemonAppIdURI
+    $daemonservicePrincipal = New-AzureADServicePrincipal  -AppId $daemonApplication.AppId
+
     # Generate a certificate
     Write-Host "Creating the client appplication ($daemonAadAppName)"
     $certificate=New-SelfSignedCertificate -Subject $certificateName -CertStoreLocation "Cert:\CurrentUser\My"  -KeyExportPolicy Exportable -KeySpec Signature 
     $certKeyId = [Guid]::NewGuid()
-
-    # Create Azure Key Credentials from the certificate
-    $keyCredential = New-Object Microsoft.Azure.Commands.Resources.Models.ActiveDirectory.PSADKeyCredential
-    $keyCredential.KeyId = $certKeyId
-    $keyCredential.CertValue = [System.Convert]::ToBase64String($certificate.GetRawCertData())
-    $keyCredential.StartDate = $certificate.NotBefore
-    $keyCredential.EndDate= $certificate.NotAfter
-
-    # And create the daemon application
-    $daemonApplication = New-AzureRmADApplication -DisplayName $daemonAadAppName -HomePage $daemonHomePage -IdentifierUris $daemonAppIdIRI -KeyCredentials $keyCredential
-    $daemonservicePrincipal = New-AzureRmADServicePrincipal -ApplicationId $daemonApplication.ApplicationId
+    $certBase64Value = [System.Convert]::ToBase64String($certificate.GetRawCertData())
+    $certBase64Thumbprint = [System.Convert]::ToBase64String($certificate.GetCertHash())
+    
+    # Add a Azure Key Credentials from the certificate for the application
+    $applicationKeyCredentials = New-AzureADApplicationKeyCredential -ObjectId $daemonApplication.ObjectId -CustomKeyIdentifier $certificateName -Type AsymmetricX509Cert -Usage Verify -Value $certBase64Value  -StartDate $certificate.NotBefore -EndDate $certificate.NotAfter
 
     # Update the config file in the daemon application
     $configFile = $pwd.Path + "\TodoListDaemonWithCert\App.Config"
     Write-Host "Updating the configuration file for the client ($configFile)"
-    UpdateClientConfigFile -configFilePath $configFile -tenantId $tenantId -clientId $daemonApplication.ApplicationId -appUri $serviceAppIdIRI -baseAddress $serviceHomePage -certificateName $certificateName
+    UpdateClientConfigFile -configFilePath $configFile -tenantId $tenantId -clientId $daemonApplication.AppId -appUri $serviceAppIdURI -baseAddress $serviceHomePage -certificateName $certificateName
 
     # Update tehe config file in the service application
     $configFile = $pwd.Path + "\TodoListService\Web.Config"
     Write-Host "Updating the client sample ($configFile)"
-    UpdateServiceConfigFile -configFilePath $configFile -tenantId $tenantId -audience $serviceAppIdIRI
+    UpdateServiceConfigFile -configFilePath $configFile -tenantId $tenantId -audience $serviceAppIdURI
 
     # prepare the clean-up
-    $applicationsInformation = @{serviceApp=$serviceApplication; serviceAppServicePrincipal=$serviceservicePrincipal; clientApp=$daemonApplication; clientAppServicePrincipal=$daemonservicePrincipal;}
+    $applicationsInformation = @{serviceApp=$serviceApplication; serviceAppServicePrincipal=$serviceservicePrincipal; clientApp=$daemonApplication; clientAppServicePrincipal=$daemonservicePrincipal; certificateThumbPrint=$certBase64Thumbprint}
     return $applicationsInformation
    }
 }
@@ -146,10 +146,10 @@ of the visual studio solution (App.Config and Web.Config) so that they are consi
 #Clean-Ups the applications and serice principal in Azure AD.
 Function CleanUp($applicationsInformation)
 {
-    remove-azurermadserviceprincipal -objectid $applicationsInformation.serviceAppServicePrincipal.id -force
-    remove-azurermadapplication -objectid $applicationsInformation.serviceApp.objectid -force
-    remove-azurermadserviceprincipal -objectid $applicationsInformation.clientAppServicePrincipal.id -force
-    remove-azurermadapplication -objectid $applicationsInformation.clientApp.objectid -force
+    remove-azurermadserviceprincipal -objectid $applicationsInformation.serviceAppServicePrincipal.id
+    remove-azurermadapplication -objectid $applicationsInformation.serviceApp.objectid
+    remove-azurermadserviceprincipal -objectid $applicationsInformation.clientAppServicePrincipal.id
+    remove-azurermadapplication -objectid $applicationsInformation.clientApp.objectid
 }
 
 $apps = ConfigureApplications

--- a/Configure.ps1
+++ b/Configure.ps1
@@ -143,7 +143,7 @@ of the visual studio solution (App.Config and Web.Config) so that they are consi
 }
 
 
-#Clean-Ups the applications and serice principal in Azure AD.
+# Remove the AAD applications and service principals registered for the sample.
 Function CleanUp($applicationsInformation)
 {
     remove-azurermadserviceprincipal -objectid $applicationsInformation.serviceAppServicePrincipal.id

--- a/Configure.ps1
+++ b/Configure.ps1
@@ -23,9 +23,9 @@
 # 6) Optionnaly if you want to cleanup the applications in the Azure AD, run:
 #      CleanUp $apps
 #    The applications are un-registered
+param([PSCredential]$Credential, [string]$TenantId)
 Import-Module AzureAD
 $ErrorActionPreference = 'Stop'
-
 
 # Replace the value of an appsettings of a given key in an XML App.Config file.
 Function ReplaceSetting([string] $configFilePath, [string] $key, [string] $newValue)
@@ -76,6 +76,7 @@ so that they are consistent with the Applications parameters
     [CmdletBinding()]
     param(
         [Parameter(Mandatory=$True, HelpMessage='Tenant ID (This is a GUID which represents the "Directory ID" of the AzureAD tenant into which you want to create the apps')]
+        [PSCredential] $Credential,
         [string] $tenantId
     )
 
@@ -84,8 +85,24 @@ so that they are consistent with the Applications parameters
     # $tenantId is the Active Directory Tenant. This is a GUID which represents the "Directory ID" of the AzureAD tenant 
     # into which you want to create the apps. Look it up in the Azure portal in the "Properties" of the Azure AD. 
 
-    # Login to Azure PowerShell (interactive: you'll need to sign-in with creds enabling your to create apps in the tenant)
-    $creds = Connect-AzureAD -TenantId $tenantId
+    # Login to Azure PowerShell (interactive if credentials are not already provided: 
+    # you'll need to sign-in with creds enabling your to create apps in the tenant)
+    if (!$Credential)
+    {
+        $creds = Connect-AzureAD -TenantId $tenantId
+    }
+    else
+    {
+        if (!$TenantId)
+        {
+            $creds = Connect-AzureAD -Credential $Credential
+        }
+        else
+        {
+            $creds = Connect-AzureAD -TenantId $tenantId -Credential $Credential
+        }
+    }
+
     if (!$tenantId)
     {
         $tenantId = $creds.Tenant.Id
@@ -171,9 +188,9 @@ Function CleanUp($applicationsInformation)
 
 
 # Run interactively (will ask you for the tenant ID)
-$apps = ConfigureApplications 
+$apps = ConfigureApplications -Credential $Credential -tenantId $TenantId
 
-# you can also provide the tenant ID
+# you can also provide the tenant ID and the credentials
 # $tenantId = "ID of your AAD directory"
 # $apps = ConfigureApplications -tenantId $tenantId 
 

--- a/Configure.ps1
+++ b/Configure.ps1
@@ -1,32 +1,34 @@
-# This script creates the Azure AD applications needed for this sample and update the configuration files
+# This script creates the Azure AD applications needed for this sample and updates the configuration files
 # for the visual Studio projects from the data in the Azure AD applications.
 #
-# Before running this script you need to install the Azure RM cmdlets as an administrator. 
+# Before running this script you need to install the AzureAD cmdlets as an administrator. 
 # For this:
 # 1) Run Powershell as an administrator
 # 2) in the PowerShell window, type: Install-Module AzureAD
-
-# To prepare this script
+#
+# Before you run this script
 # 3) With the Azure portal (https://portal.azure.com), choose your active directory tenant, then go to the Properties of the tenant and copy
 #    the DirectoryID. This is what we'll use in this script for the tenant ID
 # 
 # To configurate the applications
 # 4) Run the following command:
 #      $apps = ConfigureApplications -tenantId [place here the GUID representing the tenant ID]
+#    You will be prompted by credentials, be sure to enter credentials for a user who can create applications
+#    in the tenant
 #
 # To execute the samples
 # 5) Build and execute the applications. This just works
 #
 # To cleanup
 # 6) Optionnaly if you want to cleanup the applications in the Azure AD, run:
-#      Cleanup $apps
+#      CleanUp $apps
 #    The applications are un-registered
-
+Import-Module AzureAD
 $ErrorActionPreference = 'Stop'
 
 
 # Replace the value of an appsettings of a given key in an XML App.Config file.
-Function ReplaceSetting([string] $configFilePath, [string] $key, [string]$newValue)
+Function ReplaceSetting([string] $configFilePath, [string] $key, [string] $newValue)
 {
     [xml] $content = Get-Content $configFilePath
     $appSettings = $content.configuration.appSettings; 
@@ -67,8 +69,9 @@ Function ConfigureApplications
 {
 <#
 .Description
-This function creates the Azure AD applications for the sample in the provided Azure AD tenant and updates the configuration files in the client and service project 
-of the visual studio solution (App.Config and Web.Config) so that they are consistent with the Applications parameters
+This function creates the Azure AD applications for the sample in the provided Azure AD tenant and updates the
+configuration files in the client and service project  of the visual studio solution (App.Config and Web.Config)
+so that they are consistent with the Applications parameters
 #>
     [CmdletBinding()]
     param(
@@ -78,23 +81,22 @@ of the visual studio solution (App.Config and Web.Config) so that they are consi
 
    process
    {
-    # Active Directory Tenant. This is a GUID which represents the "Directory ID" of the AzureAD tenant into which you want to create the apps.
-    # Look it up in the Azure portal in the "Properties" of the Azure AD. 
-    # IN THE FUTURE: We'd like to be able to get the tenant name from the tenant ID (or pass the tenant name as an argument)
+    # $tenantId is the Active Directory Tenant. This is a GUID which represents the "Directory ID" of the AzureAD tenant 
+    # into which you want to create the apps. Look it up in the Azure portal in the "Properties" of the Azure AD. 
 
     # Login to Azure PowerShell (interactive: you'll need to sign-in with creds enabling your to create apps in the tenant)
     $creds = Connect-AzureAD -TenantId $tenantId
-     if (!$tenantId)
-     {
-         $tenantId = $creds.Tenant.Id
-     }
+    if (!$tenantId)
+    {
+        $tenantId = $creds.Tenant.Id
+    }
     $tenant = Get-AzureADTenantDetail
     $tenantName =  $tenant.VerifiedDomains[0].Name
 
     # Variables for the registration of the AAD application for the Web API Service
     $serviceAadAppName = "TodoListService"
     $serviceHomePage = "https://localhost:44321"
-    $serviceAppIdURI = "https://"+$tenantName+"/"+$serviceAadAppName
+    $serviceAppIdURI = "https://$tenantName/$serviceAadAppName"
 
     # Variables for the registration of the AAD application for the Daemon app
     $daemonAadAppName = "TodoListDaemonWithCert"
@@ -102,39 +104,54 @@ of the visual studio solution (App.Config and Web.Config) so that they are consi
     $daemonAppIdURI = "http://TodoListDaemonWithCert"
     $certificateName = "CN=TodoListDaemonWithCert"
 
-
     # Create the Azure Active Directory Application and it's service principal
-    # Note that if, at this point, you get an error: "New-AzureRmADApplication : Your Azure credentials have not been set up or have expired, please run Login-AzureRMAccount to set up your Azure credentials"
-    # then you will need to run Clear-AzureProfile (you might have an expired token)
     Write-Host "Creating the service appplication ($serviceAadAppName)"
-    $serviceApplication =New-AzureADApplication -DisplayName $serviceAadAppName -HomePage $serviceHomePage -IdentifierUris $serviceAppIdURI
+    $serviceApplication = New-AzureADApplication -DisplayName $serviceAadAppName `
+                                                 -HomePage $serviceHomePage `
+                                                 -IdentifierUris $serviceAppIdURI
     $serviceservicePrincipal = New-AzureADServicePrincipal -AppId $serviceApplication.AppId
 
     # Create the daemon application
-    # ------------------------------
-    # And create the daemon application
-    $daemonApplication = New-AzureADApplication  -DisplayName $daemonAadAppName -HomePage $daemonHomePage -IdentifierUris $daemonAppIdURI
+    $daemonApplication = New-AzureADApplication -DisplayName $daemonAadAppName `
+                                                -HomePage $daemonHomePage `
+                                                -IdentifierUris $daemonAppIdURI
     $daemonservicePrincipal = New-AzureADServicePrincipal  -AppId $daemonApplication.AppId
 
     # Generate a certificate
     Write-Host "Creating the client appplication ($daemonAadAppName)"
-    $certificate=New-SelfSignedCertificate -Subject $certificateName -CertStoreLocation "Cert:\CurrentUser\My"  -KeyExportPolicy Exportable -KeySpec Signature 
+    $certificate=New-SelfSignedCertificate -Subject $certificateName `
+                                           -CertStoreLocation "Cert:\CurrentUser\My" `
+                                           -KeyExportPolicy Exportable `
+                                           -KeySpec Signature 
     $certKeyId = [Guid]::NewGuid()
     $certBase64Value = [System.Convert]::ToBase64String($certificate.GetRawCertData())
     $certBase64Thumbprint = [System.Convert]::ToBase64String($certificate.GetCertHash())
     
-    # Add a Azure Key Credentials from the certificate for the application
-    $applicationKeyCredentials = New-AzureADApplicationKeyCredential -ObjectId $daemonApplication.ObjectId -CustomKeyIdentifier $certificateName -Type AsymmetricX509Cert -Usage Verify -Value $certBase64Value  -StartDate $certificate.NotBefore -EndDate $certificate.NotAfter
+    # Add a Azure Key Credentials from the certificate for the daemon application
+    $applicationKeyCredentials = New-AzureADApplicationKeyCredential -ObjectId $daemonApplication.ObjectId `
+                                                                     -CustomKeyIdentifier $certificateName `
+                                                                     -Type AsymmetricX509Cert `
+                                                                     -Usage Verify `
+                                                                     -Value $certBase64Value `
+                                                                     -StartDate $certificate.NotBefore `
+                                                                     -EndDate $certificate.NotAfter
 
     # Update the config file in the daemon application
     $configFile = $pwd.Path + "\TodoListDaemonWithCert\App.Config"
     Write-Host "Updating the configuration file for the client ($configFile)"
-    UpdateClientConfigFile -configFilePath $configFile -tenantId $tenantId -clientId $daemonApplication.AppId -appUri $serviceAppIdURI -baseAddress $serviceHomePage -certificateName $certificateName
+    UpdateClientConfigFile -configFilePath $configFile `
+       -tenantId $tenantId `
+       -clientId $daemonApplication.AppId `
+       -appUri $serviceAppIdURI `
+       -baseAddress $serviceHomePage `
+       -certificateName $certificateName
 
-    # Update tehe config file in the service application
+    # Update the config file in the service application
     $configFile = $pwd.Path + "\TodoListService\Web.Config"
     Write-Host "Updating the client sample ($configFile)"
-    UpdateServiceConfigFile -configFilePath $configFile -tenantId $tenantId -audience $serviceAppIdURI
+    UpdateServiceConfigFile -configFilePath $configFile `
+                            -tenantId $tenantId `
+                            -audience $serviceAppIdURI
 
     # prepare the clean-up
     $applicationsInformation = @{serviceApp=$serviceApplication; serviceAppServicePrincipal=$serviceservicePrincipal; clientApp=$daemonApplication; clientAppServicePrincipal=$daemonservicePrincipal; certificateThumbPrint=$certBase64Thumbprint}
@@ -144,13 +161,23 @@ of the visual studio solution (App.Config and Web.Config) so that they are consi
 
 
 # Remove the AAD applications and service principals registered for the sample.
-Function Cleanup($applicationsInformation)
+Function CleanUp($applicationsInformation)
 {
-    remove-azurermadserviceprincipal -objectid $applicationsInformation.serviceAppServicePrincipal.id
-    remove-azurermadapplication -objectid $applicationsInformation.serviceApp.objectid
-    remove-azurermadserviceprincipal -objectid $applicationsInformation.clientAppServicePrincipal.id
-    remove-azurermadapplication -objectid $applicationsInformation.clientApp.objectid
+    Remove-AzureADServicePrincipal -ObjectId $applicationsInformation.serviceAppServicePrincipal.ObjectId
+    Remove-AzureADApplication -ObjectId $applicationsInformation.serviceApp.ObjectId
+    Remove-AzureADServicePrincipal -ObjectId $applicationsInformation.clientAppServicePrincipal.ObjectId
+    Remove-AzureADApplication -ObjectId $applicationsInformation.clientApp.ObjectId
 }
 
-$apps = ConfigureApplications
-# Cleanup($apps)
+
+# Run interactively (will ask you for the tenant ID)
+$apps = ConfigureApplications 
+
+# you can also provide the tenant ID
+# $tenantId = "ID of your AAD directory"
+# $apps = ConfigureApplications -tenantId $tenantId 
+
+
+# When you have built your Visual Studio solution and ran the code, if you want to clean up the Azure AD applications, just 
+# run the following command in the same PowerShell window as you ran ConfigureApplications
+# CleanUp($apps)

--- a/Daemon-CertificateCredential-DotNet.sln
+++ b/Daemon-CertificateCredential-DotNet.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26228.0
+VisualStudioVersion = 15.0.26228.4
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TodoListService", "TodoListService\TodoListService.csproj", "{047CDEF7-D5BA-4B1E-9748-910B610CCA51}"
 EndProject
@@ -9,7 +9,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TodoListDaemonWithCert", "T
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{C7F44F54-B18B-4830-8A19-6FA17378D7B0}"
 	ProjectSection(SolutionItems) = preProject
+		Cleanup.ps1 = Cleanup.ps1
 		Configure.ps1 = Configure.ps1
+		Parameters.ps1 = Parameters.ps1
+		README.md = README.md
 	EndProjectSection
 EndProject
 Global

--- a/Manual-Configuration-Steps.md
+++ b/Manual-Configuration-Steps.md
@@ -1,0 +1,109 @@
+---
+services: active-directory
+platforms: dotnet
+author: dstrockis,jmprieur
+---
+
+# Authenticating to Azure AD in daemon apps with certificates - manual configuration steps
+This page explains how to register the sample with your Azure Active Directory and how to configure the code to use your Azure AD tenant.
+Alternatively the [Readme.md](./Readme.md) presents how to use a PowerShell script to  do the same thing automatically
+
+### Step 1:  Register the sample with your Azure Active Directory tenant
+
+There are two projects in this sample.  Each project needs to be separately registered in your Azure AD tenant.
+
+#### Register the TodoListService web API
+
+1. Sign in to the [Azure portal](https://portal.azure.com).
+2. On the top bar, click on your account and under the **Directory** list, choose the Active Directory tenant where you wish to register your application.
+2. Click on **More Services** in the left hand nav, and choose **Azure Active Directory**.
+3. Click on **App registrations** and choose **Add**.
+4. Enter a friendly name for the application, for example 'TodoListService' and select 'Web Application and/or Web API' as the Application Type. For the sign-on URL, enter the base URL for the sample, which is by default `https://localhost:44321`. For the App ID URI, enter `https://<your_tenant_name>/TodoListService`, replacing `<your_tenant_name>` with the name of your Azure AD tenant. Click on **Create** to create the application.
+5. While still in the Azure portal, choose your application, click on **Settings** and choose **Properties**.
+6. Find the Application ID value and copy it to the clipboard.
+
+#### Register the TodoListDaemonWithCert app
+
+
+1. Sign in to the [Azure portal](https://portal.azure.com).
+2. On the top bar, click on your account and under the **Directory** list, choose the Active Directory tenant where you wish to register your application.
+2. Click on **More Services** in the left hand nav, and choose **Azure Active Directory**.
+3. Click on **App registrations** and choose **Add**.
+4. Enter a friendly name for the application, for example 'TodoListDaemonWithCert' and select *'Web Application and/or Web API'* as the Application Type (even if here we have a console application). 
+5. Since this application is a daemon and not a web application, it doesn't have a sign-in URL or app ID URI.  For these two fields, enter "http://TodoListDaemonWithCert". Click on **Create** to create the application.
+6. While still in the Azure portal, choose your application, click on **Settings** and choose **Properties**.
+7. Find the Application ID value and copy it to the clipboard.
+
+
+#### Create a self-signed certificate
+
+To complete this step you will use the `New-SelfSignedCertificate` Powershell command. You can find more information about the New-SelfSignedCertificat command [here](https://technet.microsoft.com/library/hh848633).
+
+Open PowerShell and run New-SelfSignedCertificate with the following parameters to create a self-signed certificate in the user certificate store on your computer:
+
+```
+$cert=New-SelfSignedCertificate -Subject "CN=TodoListDaemonWithCert" -CertStoreLocation "Cert:\CurrentUser\My"  -KeyExportPolicy Exportable -KeySpec Signature 
+```
+
+If needed you can later export this certificate using the "Manage User Certificate" MMC snap-in accessible from the Windows Control Panel. You can also add other options to generate the certificate in a different
+store such as the Computer or service store (See [How to: View Certificates with the MMC Snap-in](https://msdn.microsoft.com/en-us/library/ms788967)).
+
+#### Add the certificate as a key for the TodoListDaemonWithCert application in Azure AD
+##### Generate a textual file containing the certificate credentials in a form consumable by AzureAD
+Copy and paste the following lines in the sam PowerShell window. They generate a text file in the current folder containing information that you can use to upload your certificate to Azure AD:
+
+```
+$bin = $cert.RawData
+$base64Value = [System.Convert]::ToBase64String($bin)
+$bin = $cert.GetCertHash()
+$base64Thumbprint = [System.Convert]::ToBase64String($bin)
+$keyid = [System.Guid]::NewGuid().ToString()
+$jsonObj = @{customKeyIdentifier=$base64Thumbprint;keyId=$keyid;type="AsymmetricX509Cert";usage="Verify";value=$base64Value}
+$keyCredentials=ConvertTo-Json @($jsonObj) | Out-File "keyCredentials.txt"
+
+```
+ The content of the generated "keyCredentials.txt" file has the following schema: 
+```
+[
+    {
+        "customKeyIdentifier": "$base64Thumbprint_from_above",
+        "keyId": "$keyid_from_above",
+        "type": "AsymmetricX509Cert",
+        "usage": "Verify",
+        "value":  "$base64Value_from_above"
+    }
+]
+```
+
+##### Associate the certificate credentials with the Azure AD Application
+To associate the certificate credential with the TodoListDaemonWithCert app object in Azure AD, you will need to edit  the application manifest. In the Azure Management Portal app registration for the `TodoListDaemonWithCert`
+click on **Manifest**. A blade opens enabling you to edit the manifest.
+You need to replace the value of the `keyCredentials` property (that is `[]` if you don't have any certificate credentials yet), with the content of the keyCredential.txt file 
+
+To do this replacement in the manifest, you have two options:
+- Option 1: Edit the manifest in place by clicking **Edit**, replacing the keyCredentials value, and then clicking **Save**. 
+Note that if you refresh the web page, the key is displayed with different properties than what you have input. In particular, you can now see the endDate, and stateDate, and the vlaue is shown as null. This is normal. 
+
+- Option 2: **Download** the manifest to your computer, edit it with your favorite text editor, save a copy of it, and **Upload** this copy. You might want to choose this option if you want to keep track of the history of the manifest.
+
+Note that the `keyCredentials` property is multi-valued, so you may upload multiple certificates for richer key management. In that case copy only the text between the curly brackets.
+
+
+### Step 2:  Configure the sample to use your Azure AD tenant
+
+#### Configure the TodoListDaemon project
+
+1. Open `app.config'.
+2. Find the app key `ida:Tenant` and replace the value with your AAD tenant name.
+3. Find the app key `ida:ClientId` and replace the value with the Client ID for the TodoListDaemonWithCert app registration from the Azure portal.
+4. Find the app key `ida:CertName` and replace the value with the subject name of the self-signed certificate you created, e.g. "CN=TodoListDaemonWithCert".
+5. Find the app key `todo:TodoListResourceId` and replace the value with the  App ID URI of the TodoListService, for example `https://<your_tenant_name>/TodoListService`
+6. Find the app key `todo:TodoListBaseAddress` and replace the value with the base address of the TodoListService project.
+
+#### Configure the TodoListService project
+
+1. Open the solution in Visual Studio 2013.
+2. Open the `web.config` file.
+3. Find the app key `ida:Tenant` and replace the value with your AAD tenant name.
+4. Find the app key `ida:Audience` and replace the value with the App ID URI you registered earlier, for example `https://<your_tenant_name>/TodoListService`.
+5. Find the app key `ida:ClientId` and replace the value with the Client ID for the TodoListService from the Azure portal.

--- a/Manual-Configuration-Steps.md
+++ b/Manual-Configuration-Steps.md
@@ -106,4 +106,3 @@ Note that the `keyCredentials` property is multi-valued, so you may upload multi
 2. Open the `web.config` file.
 3. Find the app key `ida:Tenant` and replace the value with your AAD tenant name.
 4. Find the app key `ida:Audience` and replace the value with the App ID URI you registered earlier, for example `https://<your_tenant_name>/TodoListService`.
-5. Find the app key `ida:ClientId` and replace the value with the Client ID for the TodoListService from the Azure portal.

--- a/Manual-Configuration-Steps.md
+++ b/Manual-Configuration-Steps.md
@@ -6,7 +6,7 @@ author: dstrockis,jmprieur
 
 # Authenticating to Azure AD in daemon apps with certificates - manual configuration steps
 This page explains how to register the sample with your Azure Active Directory and how to configure the code to use your Azure AD tenant.
-Alternatively the [Readme.md](./Readme.md) presents how to use a PowerShell script to  do the same thing automatically
+Alternatively the [Readme.md](./README.md) presents how to use a PowerShell script to  do the same thing automatically
 
 ### Step 1:  Register the sample with your Azure Active Directory tenant
 

--- a/Parameters.ps1
+++ b/Parameters.ps1
@@ -5,6 +5,6 @@
 
     # Variables for the registration of the AAD application for the Daemon app
     $daemonAadAppName = "TodoListDaemonWithCert"
-    $daemonHomePage = "http://TodoListDaemonWithCert"
-    $daemonAppIdURI = "http://TodoListDaemonWithCert"
+    $daemonHomePage = "https://TodoListDaemonWithCert"
+    $daemonAppIdURI = "https://TodoListDaemonWithCert"
     $certificateName = "CN=TodoListDaemonWithCert"

--- a/Parameters.ps1
+++ b/Parameters.ps1
@@ -1,0 +1,10 @@
+   # Variables for the registration of the AAD application for the Web API Service
+    $serviceAadAppName = "TodoListService"
+    $serviceHomePage = "https://localhost:44321"
+    $serviceAppIdURI = "https://$tenantName/$serviceAadAppName"
+
+    # Variables for the registration of the AAD application for the Daemon app
+    $daemonAadAppName = "TodoListDaemonWithCert"
+    $daemonHomePage = "http://TodoListDaemonWithCert"
+    $daemonAppIdURI = "http://TodoListDaemonWithCert"
+    $certificateName = "CN=TodoListDaemonWithCert"

--- a/Parameters.ps1
+++ b/Parameters.ps1
@@ -5,6 +5,6 @@
 
     # Variables for the registration of the AAD application for the Daemon app
     $daemonAadAppName = "TodoListDaemonWithCert"
-    $daemonHomePage = "https://TodoListDaemonWithCert"
-    $daemonAppIdURI = "https://TodoListDaemonWithCert"
+    $daemonHomePage = "https://$daemonAadAppName"
+    $daemonAppIdURI = "https://$daemonAadAppName"
     $certificateName = "CN=TodoListDaemonWithCert"

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ There are two options:
 If you want to understand in more depth what needs to be done in the Azure portal, and how to change the code (Option 2), please have a look at [Manual-Configuration-Steps.md](./Manual-Configuration-Steps.md). Otherwise (Option 1), the steps to use the PowerShell are the following:
 
 #### Find your tenant ID
-I might be that the user you want to create Azure Active Directory applications with can do it in several active directories. In that case to disambiguate in which active directory to create the applications, you will need to provide its tenant ID. Here is how to get it:
+If you have access to multiple Azure Active Directory tenants, you must specify the ID of the tenant in which you wish to create the applications. Here's how to find you tenant ID:
  1. Sign in to the [Azure portal](https://portal.azure.com).
  2. On the top bar, click on your account and under the **Directory** list, choose the Active Directory tenant where you wish to register your application.
  3. Click on **More Services** in the left hand nav, and choose **Azure Active Directory**.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,9 @@ author: dstrockis,jmprieur
 # Authenticating to Azure AD in daemon apps with certificates
 ![](https://identitydivision.visualstudio.com/_apis/public/build/definitions/a7934fdd-dcde-4492-a406-7fad6ac00e17/30/badge)
 
-This sample is similar to [Daemon-DotNet](https://github.com/Azure-Samples/active-directory-dotnet-daemon), except instead of the daemon using a password as a credential to authenticate with Azure AD, it uses a certificate.
+In this sample a Windows console application (TodoListDaemonWithCert) calls a web API (TodoListService) using its app identity. This scenario is useful for situations where headless or unattended job or process needs to run as an application identity, instead of as a user's identity. The application uses the Active Directory Authentication Library (ADAL) to get a token from Azure AD using the OAuth 2.0 client credential flow, where the client credential is a certificate.
+
+This sample is similar to [Daemon-DotNet](https://github.com/Azure-Samples/active-directory-dotnet-daemon), except instead of the daemon using a password as a credential to authenticate with Azure AD, here it uses a certificate.
 
 For more information about how the protocols work in this scenario and other scenarios, see [Authentication Scenarios for Azure AD](http://go.microsoft.com/fwlink/?LinkId=394414) and [Service to service calls using client credentials](https://github.com/Microsoft/azure-docs/blob/master/articles/active-directory/develop/active-directory-protocols-oauth-service-to-service.md)
 
@@ -16,9 +18,11 @@ For more information about how the protocols work in this scenario and other sce
 ## How to Run this sample
 
 To run this sample, you will need:
-- Visual Studio 2013 or above
-- An Internet connection
-- An Azure Active Directory (Azure AD) tenant. For more information on how to get an Azure AD tenant, please see [How to get an Azure AD tenant](https://azure.microsoft.com/en-us/documentation/articles/active-directory-howto-tenant/) 
+ - Visual Studio 2013 or above (also tested with Visual Studio 2015 and Visual Studio 2017)
+ - An Internet connection
+ - An Azure Active Directory (Azure AD) tenant. For more information on how to get an Azure AD tenant, please see [How to get an Azure AD tenant](https://azure.microsoft.com/en-us/documentation/articles/active-directory-howto-tenant/)
+ - (Optional) If you want automatically create the applications in AAD corresponding to the daemon and service, and update the configuration files in their respective Visual Studio projects, you can run a script which requires Azure AD PowerShell. For details on how to install it, please see [the Azure Active Directory V2 PowerShell Module](https://www.powershellgallery.com/packages/AzureAD/). 
+ Alternatively, you also have the option of configuring the applications  manually through the Azure portal and by editing the code.
 
 ### Step 1:  Clone or download this repository
 
@@ -28,7 +32,11 @@ You can clone this repository from Visual Studio. Alternatively, from your shell
 
 ### Step 2:  Register the sample with your Azure Active Directory tenant and configure the code accordingly
 
-If you want to understand in more depth what needs to be done in the Azure portal, and how to change the code, please have a look at [Manual-Configuration-Steps.md](./Manual-Configuration-Steps.md). Otherwise, you can use a PowerShell Script. The steps are the following:
+There are two options:
+ - Option 1: you run the `Configure.ps1` PowerShell script which creates two applications in the Azure Active Directory, (one for the client and one for the service), and then updates the configuration files in the Visual Studio projects to point to those two newly created apps
+ - Option 2: you do the same manually.
+
+If you want to understand in more depth what needs to be done in the Azure portal, and how to change the code (Option 2), please have a look at [Manual-Configuration-Steps.md](./Manual-Configuration-Steps.md). Otherwise (Option 1), the steps to use the PowerShell are the following:
 
 #### Find your tenant ID
  1. Sign in to the [Azure portal](https://portal.azure.com).
@@ -95,7 +103,7 @@ Clean the solution, rebuild the solution, and run it.  You might want to go into
  2. choose **Multiple startup projects**
   - TodoListDaemonWithCert: **Start**
   - TodoListService: Start **Start without debugging**
- 3. In VS press the **start** button: a web window appears running the service and a console application runs the dameon application under debugger. you can set breakpoints to understand the call to ADAL.NET.
+ 3. In the Visual Studio tool bar, press the **start** button: a web window appears running the service and a console application runs the dameon application under debugger. you can set breakpoints to understand the call to ADAL.NET.
 
 The daemon will add items to its To Do list and then read them back.
 

--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@ services: active-directory
 platforms: dotnet
 author: dstrockis,jmprieur
 ---
-
 # Authenticating to Azure AD in daemon apps with certificates
+
 ![](https://identitydivision.visualstudio.com/_apis/public/build/definitions/a7934fdd-dcde-4492-a406-7fad6ac00e17/30/badge)
 
 In this sample a Windows console application (TodoListDaemonWithCert) calls a web API (TodoListService) using its app identity. This scenario is useful for situations where headless or unattended job or process needs to run as an application identity, instead of as a user's identity. The application uses the Active Directory Authentication Library (ADAL) to get a token from Azure AD using the OAuth 2.0 client credential flow, where the client credential is a certificate.
@@ -39,6 +39,7 @@ There are two options:
 If you want to understand in more depth what needs to be done in the Azure portal, and how to change the code (Option 2), please have a look at [Manual-Configuration-Steps.md](./Manual-Configuration-Steps.md). Otherwise (Option 1), the steps to use the PowerShell are the following:
 
 #### Find your tenant ID
+I might be that the user you want to create Azure Active Directory applications with can do it in several active directories. In that case to disambiguate in which active directory to create the applications, you will need to provide its tenant ID. Here is how to get it:
  1. Sign in to the [Azure portal](https://portal.azure.com).
  2. On the top bar, click on your account and under the **Directory** list, choose the Active Directory tenant where you wish to register your application.
  3. Click on **More Services** in the left hand nav, and choose **Azure Active Directory**.
@@ -54,7 +55,9 @@ If you want to understand in more depth what needs to be done in the Azure porta
         
     The script executes and provisions the AAD applications (If you look at the AAD applications in the portal after that the script has run, you'll have two additional applications). The script also updates two configuration files in the Visual Studio solution (`TodoListDaemonWithCert\App.Config` and `TodoListService\Web.Config`)
 
-6. If you intend to clean up the azure AD applications from the Azure AD tenant after running the sample, keep the PowerShell ISE window opened.
+ 6. If you intend to clean up the azure AD applications from the Azure AD tenant after running the sample see Step 5 below.
+
+Note that if you are familiar with PowerShell it's also possible to start a PowerShell command window, and run ``. .\Configure.ps1`` providing your credentials directly (and the tenant ID if there is ambiguity).
 
 ### Step 3:  Trust the IIS Express SSL certificate
 
@@ -107,11 +110,12 @@ Clean the solution, rebuild the solution, and run it.  You might want to go into
 
 The daemon will add items to its To Do list and then read them back.
 
-### Step 4:  Clean up the applications in the Azure AD tenant
-When you are done with running and understanding the sample, if you want to remove your Applications from AD and if you have keep your PowerShell ISE window opened, just run, in the same PowerShell ISE window:
+### Step 5:  Clean up the applications in the Azure AD tenant
+When you are done with running and understanding the sample, if you want to remove your Applications from AD just run:
 
-``CleanUp($apps)``
+``. .\Cleanup.ps1``
 
+Again you will be asked for your tenant ID.
 If you do that you also probably want to undo the changes in the `App.config` and `Web.Config`
 
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ---
 services: active-directory
 platforms: dotnet
-author: dstrockis
+author: dstrockis,jmprieur
 ---
 
 # Authenticating to Azure AD in daemon apps with certificates
@@ -26,111 +26,37 @@ You can clone this repository from Visual Studio. Alternatively, from your shell
 
 `git clone https://github.com/Azure-Samples/active-directory-dotnet-daemon-certificate-credential.git`
 
-### Step 2:  Register the sample with your Azure Active Directory tenant
+### Step 2:  Register the sample with your Azure Active Directory tenant and configure the code accordingly
 
-There are two projects in this sample.  Each project needs to be separately registered in your Azure AD tenant.
+If you want to understand in more depth what needs to be done in the Azure portal, and how to change the code, please have a look at [Manual-Configuration-Steps.md](./Manual-Configuration-Steps.md). Otherwise, you can use a PowerShell Script. The steps are the following:
 
-#### Register the TodoListService web API
+#### Find your tenant ID
+ 1. Sign in to the [Azure portal](https://portal.azure.com).
+ 2. On the top bar, click on your account and under the **Directory** list, choose the Active Directory tenant where you wish to register your application.
+ 3. Click on **More Services** in the left hand nav, and choose **Azure Active Directory**.
+ 4. Click on **Properties** and copy the value of the **Directory ID** property to the clipboard. This is your tenant ID. We'll need it in the next step. 
 
-1. Sign in to the [Azure portal](https://portal.azure.com).
-2. On the top bar, click on your account and under the **Directory** list, choose the Active Directory tenant where you wish to register your application.
-2. Click on **More Services** in the left hand nav, and choose **Azure Active Directory**.
-3. Click on **App registrations** and choose **Add**.
-4. Enter a friendly name for the application, for example 'TodoListService' and select 'Web Application and/or Web API' as the Application Type. For the sign-on URL, enter the base URL for the sample, which is by default `https://localhost:44321`. For the App ID URI, enter `https://<your_tenant_name>/TodoListService`, replacing `<your_tenant_name>` with the name of your Azure AD tenant. Click on **Create** to create the application.
-5. While still in the Azure portal, choose your application, click on **Settings** and choose **Properties**.
-6. Find the Application ID value and copy it to the clipboard.
+#### Run the PowerShell script
 
-#### Register the TodoListDaemonWithCert app
+ 1. In the Visual Studio Solution explorer, right click on the solution file (.lsn) and choose **Open Folder in File Explorer**. The windows file explorer opens at the location of the solution
+ 2. In the file explorer right click on the `Configure.ps1` file and choose **Edit**, this starts PowerShell ISE and loads the PowerShell Script. You can read the comments at the beginning of the script (they provide full explanations), as well as the bottom of the script.
+ 3. In PowerShell ISE, Press the green arrow **Run script** to start the script
+ 4. At the prompt ("tenantId:") paste the tenant ID that you previously copied from the Azure portal
+ 5. When requested, sign-in as a user who has permissions to create applications in the AAD tenant. 
+        
+    The script executes and provisions the AAD applications (If you look at the AAD applications in the portal after that the script has run, you'll have two additional applications). The script also updates two configuration files in the Visual Studio solution (`TodoListDaemonWithCert\App.Config` and `TodoListService\Web.Config`)
 
+6. If you intend to clean up the azure AD applications from the Azure AD tenant after running the sample, keep the PowerShell ISE window opened.
 
-1. Sign in to the [Azure portal](https://portal.azure.com).
-2. On the top bar, click on your account and under the **Directory** list, choose the Active Directory tenant where you wish to register your application.
-2. Click on **More Services** in the left hand nav, and choose **Azure Active Directory**.
-3. Click on **App registrations** and choose **Add**.
-4. Enter a friendly name for the application, for example 'TodoListDaemonWithCert' and select *'Web Application and/or Web API'* as the Application Type (even if here we have a console application). 
-5. Since this application is a daemon and not a web application, it doesn't have a sign-in URL or app ID URI.  For these two fields, enter "http://TodoListDaemonWithCert". Click on **Create** to create the application.
-6. While still in the Azure portal, choose your application, click on **Settings** and choose **Properties**.
-7. Find the Application ID value and copy it to the clipboard.
-
-
-#### Create a self-signed certificate
-
-To complete this step you will use the `New-SelfSignedCertificate` Powershell command. You can find more information about the New-SelfSignedCertificat command [here](https://technet.microsoft.com/library/hh848633).
-
-Open PowerShell and run New-SelfSignedCertificate with the following parameters to create a self-signed certificate in the user certificate store on your computer:
-
-```
-$cert=New-SelfSignedCertificate -Subject "CN=TodoListDaemonWithCert" -CertStoreLocation "Cert:\CurrentUser\My"  -KeyExportPolicy Exportable -KeySpec Signature 
-```
-
-If needed you can later export this certificate using the "Manage User Certificate" MMC snap-in accessible from the Windows Control Panel. You can also add other options to generate the certificate in a different
-store such as the Computer or service store (See [How to: View Certificates with the MMC Snap-in](https://msdn.microsoft.com/en-us/library/ms788967)).
-
-#### Add the certificate as a key for the TodoListDaemonWithCert application in Azure AD
-##### Generate a textual file containing the certificate credentials in a form consumable by AzureAD
-Copy and paste the following lines in the sam PowerShell window. They generate a text file in the current folder containing information that you can use to upload your certificate to Azure AD:
-
-```
-$bin = $cert.RawData
-$base64Value = [System.Convert]::ToBase64String($bin)
-$bin = $cert.GetCertHash()
-$base64Thumbprint = [System.Convert]::ToBase64String($bin)
-$keyid = [System.Guid]::NewGuid().ToString()
-$jsonObj = @{customKeyIdentifier=$base64Thumbprint;keyId=$keyid;type="AsymmetricX509Cert";usage="Verify";value=$base64Value}
-$keyCredentials=ConvertTo-Json @($jsonObj) | Out-File "keyCredentials.txt"
-
-```
- The content of the generated "keyCredentials.txt" file has the following schema: 
-```
-[
-    {
-        "customKeyIdentifier": "$base64Thumbprint_from_above",
-        "keyId": "$keyid_from_above",
-        "type": "AsymmetricX509Cert",
-        "usage": "Verify",
-        "value":  "$base64Value_from_above"
-    }
-]
-```
-
-##### Associate the certificate credentials with the Azure AD Application
-To associate the certificate credential with the TodoListDaemonWithCert app object in Azure AD, you will need to edit  the application manifest. In the Azure Management Portal app registration for the `TodoListDaemonWithCert`
-click on **Manifest**. A blade opens enabling you to edit the manifest.
-You need to replace the value of the `keyCredentials` property (that is `[]` if you don't have any certificate credentials yet), with the content of the keyCredential.txt file 
-
-To do this replacement in the manifest, you have two options:
-- Option 1: Edit the manifest in place by clicking **Edit**, replacing the keyCredentials value, and then clicking **Save**. 
-Note that if you refresh the web page, the key is displayed with different properties than what you have input. In particular, you can now see the endDate, and stateDate, and the vlaue is shown as null. This is normal. 
-
-- Option 2: **Download** the manifest to your computer, edit it with your favorite text editor, save a copy of it, and **Upload** this copy. You might want to choose this option if you want to keep track of the history of the manifest.
-
-Note that the `keyCredentials` property is multi-valued, so you may upload multiple certificates for richer key management. In that case copy only the text between the curly brackets.
-
-
-### Step 3:  Configure the sample to use your Azure AD tenant
-
-#### Configure the TodoListDaemon project
-
-1. Open `app.config'.
-2. Find the app key `ida:Tenant` and replace the value with your AAD tenant name.
-3. Find the app key `ida:ClientId` and replace the value with the Client ID for the TodoListDaemonWithCert app registration from the Azure portal.
-4. Find the app key `ida:CertName` and replace the value with the subject name of the self-signed certificate you created, e.g. "CN=TodoListDaemonWithCert".
-5. Find the app key `todo:TodoListResourceId` and replace the value with the  App ID URI of the TodoListService, for example `https://<your_tenant_name>/TodoListService`
-6. Find the app key `todo:TodoListBaseAddress` and replace the value with the base address of the TodoListService project.
-
-#### Configure the TodoListService project
-
-1. Open the solution in Visual Studio 2013.
-2. Open the `web.config` file.
-3. Find the app key `ida:Tenant` and replace the value with your AAD tenant name.
-4. Find the app key `ida:Audience` and replace the value with the App ID URI you registered earlier, for example `https://<your_tenant_name>/TodoListService`.
-5. Find the app key `ida:ClientId` and replace the value with the Client ID for the TodoListService from the Azure portal.
-
-### Step 4:  Trust the IIS Express SSL certificate
+### Step 3:  Trust the IIS Express SSL certificate
 
 Since the web API is SSL protected, the client of the API (the web app) will refuse the SSL connection to the web API unless it trusts the API's SSL certificate.  Use the following steps in Windows PowerShell to trust the IIS Express SSL certificate.  You only need to do this once.  If you fail to do this step, calls to the TodoListService will always throw an unhandled exception where the inner exception message is:
 
 "The underlying connection was closed: Could not establish trust relationship for the SSL/TLS secure channel."
+
+> Recent versions of Visual Studio will propose themselves to trust the IIS Express SSL certificate. If this is not the case for your installation
+please know that you will need to do this step only once.
+
 
 To configure your computer to trust the IIS Express SSL certificate, begin by opening a Windows PowerShell command window as Administrator.
 
@@ -162,15 +88,28 @@ You can verify the certificate is in the Trusted Root store by running this comm
 
 `PS C:\windows\system32> dir Cert:\LocalMachine\Root`
 
-### Step 5:  Run the sample
+### Step 4:  Run the sample
 
-Clean the solution, rebuild the solution, and run it.  You might want to go into the solution properties and set both projects as startup projects, with the service project starting first.
+Clean the solution, rebuild the solution, and run it.  You might want to go into the solution properties and set both projects as startup projects, with the service project starting first. To do this you can for instance:
+ 1. Right click on the solution in the solution explorer and choose **Set Startup projects** from the context menu.
+ 2. choose **Multiple startup projects**
+  - TodoListDaemonWithCert: **Start**
+  - TodoListService: Start **Start without debugging**
+ 3. In VS press the **start** button: a web window appears running the service and a console application runs the dameon application under debugger. you can set breakpoints to understand the call to ADAL.NET.
 
 The daemon will add items to its To Do list and then read them back.
 
+### Step 4:  Clean up the applications in the Azure AD tenant
+When you are done with running and understanding the sample, if you want to remove your Applications from AD and if you have keep your PowerShell ISE window opened, just run, in the same PowerShell ISE window:
+
+``CleanUp($apps)``
+
+If you do that you also probably want to undo the changes in the `App.config` and `Web.Config`
+
+
 ## How to deploy this sample to Azure
 
-Coming soon.
+TBD.
 
 ## About the Code
 
@@ -195,6 +134,6 @@ First, in Visual Studio 2013 (or above) create an empty solution to host the  pr
 3. Add  assembly references to `System.Net.Http`, `System.Web.Extensions`, and `System.Configuration`.
 4. Add a new class to the project called `TodoItem.cs`.  Copy the code from the sample project file of same name into this class, completely replacing the code in the file in the new project.
 5. Copy the code from `Program.cs` in the sample project into the file of same name in the new project, completely replacing the code in the file in the new project.
-6. In `app.config` create keys for `ida:AADInstance`, `ida:Tenant`, `ida:ClientId`, `ida:CertName`, `todo:TodoListResourceId`, and `todo:TodoListBaseAddress` and set them accordingly.  For the public Azure cloud, the value of `ida:AADInstance` is `https://login.windows.net/{0}`.
+6. In `app.config` create keys for `ida:AADInstance`, `ida:Tenant`, `ida:ClientId`, `ida:CertName`, `todo:TodoListResourceId`, and `todo:TodoListBaseAddress` and set them accordingly.  For the public Azure cloud, the value of `ida:AADInstance` is `https://login.microsoftonline.com/{0}`.
 
 Finally, in the properties of the solution itself, set both projects as startup projects.

--- a/TodoListDaemonWithCert/Program.cs
+++ b/TodoListDaemonWithCert/Program.cs
@@ -58,8 +58,13 @@ namespace TodoListDaemonWithCert
         private static AuthenticationContext authContext = null;
         private static ClientAssertionCertificate certCred = null;
 
-        static void Main(string[] args)
+        private static int errorCode;
+
+        static int Main(string[] args)
         {
+            // Return code so that exceptions provoke a non null return code for the daemon
+            errorCode = 0;
+
             // Create the authentication context to be used to acquire tokens.
             authContext = new AuthenticationContext(authority);
 
@@ -78,7 +83,7 @@ namespace TodoListDaemonWithCert
                 if (signingCert.Count == 0)
                 {
                     // No matching certificate found.
-                    return;
+                    return -1;
                 }
                 // Return the first certificate in the collection, has the right name and is current.
                 cert = signingCert.OfType< X509Certificate2>().OrderByDescending(c => c.NotBefore).First();
@@ -99,6 +104,8 @@ namespace TodoListDaemonWithCert
                 Thread.Sleep(3000);
                 GetTodo().Wait();
             }
+
+            return errorCode;
         }
 
         static async Task PostTodo()
@@ -132,6 +139,8 @@ namespace TodoListDaemonWithCert
                         DateTime.Now.ToString(),
                         ex.ToString(),
                         retry.ToString()));
+
+                    errorCode = -1;
                 }
 
             } while ((retry == true) && (retryCount < 3));
@@ -198,6 +207,8 @@ namespace TodoListDaemonWithCert
                         DateTime.Now.ToString(),
                         ex.ToString(),
                         retry.ToString()));
+
+                    errorCode = -1;
                 }
 
             } while ((retry == true) && (retryCount < 3));

--- a/TodoListDaemonWithCert/Program.cs
+++ b/TodoListDaemonWithCert/Program.cs
@@ -81,7 +81,7 @@ namespace TodoListDaemonWithCert
                     return;
                 }
                 // Return the first certificate in the collection, has the right name and is current.
-                cert = signingCert[0];
+                cert = signingCert.OfType< X509Certificate2>().OrderByDescending(c => c.NotBefore).First();
             }
             finally
             {


### PR DESCRIPTION
1. Separating the Configure.ps1 in 3 PowerShell scripts:
1 (New) Parameters.ps1 which contain the parameters for the sample (name for the applications, URIs, etc ...)
2 (Updated) Configure.ps1 now imports Parameters.ps1 to create the Azure Active Directory applications and updates the Web.Config and App.Config of the Visual Studio applications to match the AAD applications. It's also possible to pass the TenantId and Credentials as parameters of the script in order to run it from a Continuous Integration / Continuous Delivery build
3 (New) Cleanup.ps1 does the cleanup of the Azure Active directory applications. the Cleanup-) function can now be ran in a different PowerShell Script, even days afterwards as it imports the parameters to find the AAD applications

Also updated the Readme.md file to explain the new way to call the scripts.